### PR TITLE
Update GCP credentials in CD workflow

### DIFF
--- a/.github/workflows/cd.yml
+++ b/.github/workflows/cd.yml
@@ -22,12 +22,10 @@ jobs:
             - id: 'auth'
               uses: 'google-github-actions/auth@v2'
               with:
-                service_account: 'cloud-run-deployer@notely-412001.iam.gserviceaccount.com'
+                credentials_json: '${{ secrets.GCP_CREDENTIALS }}'
         
             - name: 'Set up Cloud SDK'
               uses: 'google-github-actions/setup-gcloud@v2'
-              with:
-                version: '>= 363.0.0'
         
             - name: 'Use gcloud CLI'
               run: gcloud builds submit --tag us-central1-docker.pkg.dev/notely-412001/notely-ar-repo/notely:latest .


### PR DESCRIPTION
This pull request updates the GCP credentials in the CD workflow to use the `GCP_CREDENTIALS` secret instead of the service account email. This ensures that the credentials are securely stored and not exposed in the workflow file.